### PR TITLE
Add breakpoints

### DIFF
--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 
 int main() {
-    std::cout << "Hello world!";
-
+    std::cout << "Hello world!" << "\n";
     return 1;
 }


### PR DESCRIPTION
To find the address to put a breakpoint, you need to run `objdump -d <your_program>` to see the disassembly for the code. You can then find the instruction address to set the breakpoint from. However, these are relative to the address where the binary is loaded at, so you also need to read `proc/<process_id>/maps` to find the load address. You can add the breakpoint offsets to the base address to get the real address.